### PR TITLE
fix: workflow Claude Auto-Fix — syntax error en glob

### DIFF
--- a/.github/workflows/claude-auto-fix.yml
+++ b/.github/workflows/claude-auto-fix.yml
@@ -77,7 +77,7 @@ jobs:
             # Get frontend components
             if [ -d "web/modular-frontend/packages/module-$MODULE/src" ]; then
               CONTEXT="$CONTEXT\n--- FRONTEND: module-$MODULE ---\n"
-              for f in web/modular-frontend/packages/module-$MODULE/src/*.{ts,tsx} 2>/dev/null; do
+              for f in $(find web/modular-frontend/packages/module-$MODULE/src -maxdepth 1 -name "*.ts" -o -name "*.tsx" 2>/dev/null); do
                 [ -f "$f" ] && CONTEXT="$CONTEXT\n--- $f ---\n$(head -80 $f)"
               done
             fi

--- a/README.md
+++ b/README.md
@@ -29,3 +29,5 @@ Bienvenido al centro de soporte de **Zentto ERP**. Aquí puedes:
 
 ---
 *Zentto · Hecho para PYMEs que crecen*
+
+<!-- version: 2026-03-31T13:03:34.163Z -->


### PR DESCRIPTION
Fix: `for f in *.{ts,tsx} 2>/dev/null` rompe dentro de \ porque bash interpreta `2>` como redirección del command substitution exterior. Reemplazado con `find`.