### PR TITLE
fix: git config para bot commits

### DIFF
--- a/.github/workflows/claude-auto-fix.yml
+++ b/.github/workflows/claude-auto-fix.yml
@@ -275,6 +275,8 @@ jobs:
           ANALYSIS: ${{ steps.ctx.outputs.analysis }}
         run: |
           cd zentto-web
+          git config user.name "zentto-bot"
+          git config user.email "bot@zentto.net"
           BRANCH="fix/support-issue-${ISSUE_NUMBER}"
           git checkout -b "$BRANCH"
 


### PR DESCRIPTION
Faltaba git config user.name/email para que el bot pueda commitear.