### PR TITLE
feat(security): add reusable org security workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,21 @@
+name: Security
+
+on:
+  push:
+    branches: [main, developer, master]
+  pull_request:
+    branches: [main, developer, master]
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  security:
+    uses: zentto-erp/.github/.github/workflows/security.yml@main
+    with:
+      fail-on: critical
+    secrets: inherit


### PR DESCRIPTION
Integrates with the org-wide reusable security workflow at `zentto-erp/.github/.github/workflows/security.yml@main`.

**Stack:** Semgrep (SAST) + Gitleaks (secrets) + Trivy (deps/IaC/Dockerfile) + OSV-Scanner (CVE) + zizmor (Actions audit) + actionlint.

**Gate:** `fail-on: critical` inicial — no bloquea PRs por findings high/medium mientras se limpia el backlog. Se sube a `high` una vez estable.

**Triggers:** push/PR a main/developer/master + schedule semanal (lunes 06:00 UTC) + workflow_dispatch.

Ver `SECURITY.md` en `zentto-erp/.github` para detalles completos.