### PR TITLE
fix(security): least-privilege permissions in workflows

### DIFF
--- a/.github/workflows/claude-auto-fix.yml
+++ b/.github/workflows/claude-auto-fix.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [labeled]
 
+permissions:
+  contents: read
+
 jobs:
   forward-to-dev:
     if: github.event.label.name == 'ai-fix'


### PR DESCRIPTION
Añade `permissions: contents: read` top-level a workflows que no lo declaran, cerrando el hallazgo **"Workflow does not contain permissions"** reportado por zizmor/CodeQL.

**Seguridad:**
- Skip workflows que YA tienen `permissions:` top-level
- Skip workflows con operaciones privilegiadas (deploy/release/pages/publish) — se revisan manualmente
- Solo se toca workflows "read-only" (tests, type-check, lint, cron jobs)

Generado automáticamente por `_tmp-security/fix_permissions.py`.