### PR TITLE
release: developer -> main (sync ecosistema 2026-05-06)

### DIFF
--- a/.github/workflows/claude-auto-fix.yml
+++ b/.github/workflows/claude-auto-fix.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [labeled]
 
+permissions:
+  contents: read
+
 jobs:
   forward-to-dev:
     if: github.event.label.name == 'ai-fix'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,5 +17,5 @@ jobs:
   security:
     uses: zentto-erp/.github/.github/workflows/security.yml@main
     with:
-      fail-on: critical
+      fail-on: high
     secrets: inherit

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,21 @@
+name: Security
+
+on:
+  push:
+    branches: [main, developer, master]
+  pull_request:
+    branches: [main, developer, master]
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  security:
+    uses: zentto-erp/.github/.github/workflows/security.yml@main
+    with:
+      fail-on: critical
+    secrets: inherit


### PR DESCRIPTION
Promueve trabajo activo de `developer` a `main` para alinear el ecosistema. Decision PO 2026-05-06: developer es la fuente de verdad activa.